### PR TITLE
Lock dependency version for homebrew to 2.1.2

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,7 @@ depends 'yum-epel'
 depends 'build-essential'
 depends 'ark'
 depends 'apt'
-depends 'homebrew'
+depends 'homebrew', '2.1.2'
 
 %w(debian ubuntu centos redhat smartos mac_os_x).each do |os|
   supports os


### PR DESCRIPTION
## Problem
Dependency [homebrew](https://github.com/chef-cookbooks/homebrew) has released version 3.0.0, which breaks compatibility with Chef 11.10 and this causes problems when running setup on Rails instances.

## Version
Lock the version to 2.1.2, last known to work properly.