### PR TITLE
Lock yum version to 4.2.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,7 @@ version '2.4.1'
 
 conflicts 'node'
 
+depends 'yum', '4.2.0'
 depends 'yum-epel'
 depends 'build-essential'
 depends 'ark'


### PR DESCRIPTION
[RV-2510](https://fundbase.atlassian.net/browse/RV-2510)

## Problem
Dependency [yum](https://github.com/chef-cookbooks/yum) has released version 5.0.0, which breaks compatibility with Chef 11.10 and this causes problems when running deploy on Rails instances.

## Solution
Lock version of `yum` to 4.2.0 from [last working deploy](https://console.aws.amazon.com/opsworks/home?region=eu-west-1&endpoint=us-east-1#/stack/54d83309-349a-4357-907a-3d4ab1f85204/deployments/2f43b76e-d296-4f10-aa3c-146c39c05d82)