### PR TITLE
RV-2588 Lock the version of arc cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ conflicts 'node'
 depends 'yum', '4.2.0'
 depends 'yum-epel'
 depends 'build-essential'
-depends 'ark'
+depends 'ark', '2.2.1'
 depends 'apt'
 depends 'homebrew', '2.1.2'
 


### PR DESCRIPTION
## [RV-2588](https://fundbase.atlassian.net/browse/RV-2588)

## Problem
Setup is failing because the cookbook `arc` was updated, but the new version in not compatible with Chef 11.
[1](https://console.aws.amazon.com/opsworks/home?endpoint=us-east-1&region=eu-west-1#/stack/54d83309-349a-4357-907a-3d4ab1f85204/instances/07e1592c-fcd6-4495-9296-5833fcd3794f/log/55a1615e-1402-4b5f-98e4-87db8ca70fd5)
[2](https://console.aws.amazon.com/opsworks/home?endpoint=us-east-1&region=eu-west-1#/stack/54d83309-349a-4357-907a-3d4ab1f85204/instances/2940f589-7306-4904-a8b5-c62733c47919/log/89589528-753f-4814-87d8-fc6b2145633f)

## Solution
Lock the version to the previous working one.